### PR TITLE
Implement vistoriador status updates

### DIFF
--- a/controllers/botHandlers.js
+++ b/controllers/botHandlers.js
@@ -407,7 +407,7 @@ Agora você precisa informar a quilometragem inicial da viatura.
                     return;
                 }
 
-                const erro = await requestService.processarRespostaVistoriador(bot, userIdClicou, codigoSolicitacao);
+                const erro = await requestService.processarRespostaVistoriador(bot, userIdClicou, codigoSolicitacao, message);
                 if (erro) {
                     bot.answerCallbackQuery(callbackQuery.id, { text: erro });
                     return;


### PR DESCRIPTION
## Summary
- track vistoriador message ID to follow the request
- keep vistoriador status updated when keys are delivered and kilometers are entered

## Testing
- `node main.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684c31637f9083289100d0e643b9ae8d